### PR TITLE
fix: MCD-610: Remove deprecated npm options

### DIFF
--- a/devsetup-docker/Dockerfile.cli
+++ b/devsetup-docker/Dockerfile.cli
@@ -33,13 +33,8 @@ RUN apk add --update \
     imagemagick \
   && rm -rf /var/cache/apk/*
 
-# Workaround "could not get uid/gid" npm errors.
-# https://github.com/npm/npm/issues/20861
-RUN npm config set unsafe-perm true
 # Ensure ~/.config is created and make npm update check work without warnings.
 RUN mkdir -p /home/.config && chown -R $COMPOSE_DEFAULT_USER:0 /home/.config
-# Update npm.
-RUN npm install -g npm@^6.9.0
 
 # Define where the Drupal root is located.
 ENV WEBROOT=web


### PR DESCRIPTION
## Summary
- Remove `npm config set unsafe-perm true` which was removed in npm 9+
- Remove `npm install -g npm@^6.9.0` which is outdated (base image has modern npm)

These options cause Docker builds to fail on GitHub Actions runners with newer npm versions.

## Test plan
- [ ] Verify drupal-project CI passes after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)